### PR TITLE
ypy enable ints and nulls

### DIFF
--- a/src/y_xml.rs
+++ b/src/y_xml.rs
@@ -1,3 +1,4 @@
+use crate::shared_types::CompatiblePyType;
 use crate::shared_types::{SubId, TypeWithDoc};
 use crate::y_doc::{WithDoc, YDocInner};
 use lib0::any::Any;
@@ -375,8 +376,23 @@ impl YXmlElement {
 
     /// Sets a `name` and `value` as new attribute for this XML node. If an attribute with the same
     /// `name` already existed on that node, its value with be overridden with a provided one.
-    pub fn set_attribute(&self, txn: &mut YTransaction, name: &str, value: &str) -> PyResult<()> {
-        txn.transact(|txn| self.0.insert_attribute(txn, name, value))
+    pub fn set_attribute(
+        &self,
+        txn: &mut YTransaction,
+        name: &str,
+        value: Py<PyAny>,
+    ) -> PyResult<()> {
+        Python::with_gil(|py| {
+            let compatible_py_type_value: CompatiblePyType =
+                value.extract(py).unwrap_or_else(|err| {
+                    err.restore(py);
+                    CompatiblePyType::None
+                });
+            txn.transact(|txn| {
+                self.0
+                    .insert_attribute(txn, name, Any::try_from(compatible_py_type_value).unwrap())
+            })
+        })
     }
 
     /// Returns a value of an attribute given its `name`. If no attribute with such name existed,
@@ -581,8 +597,23 @@ impl YXmlText {
 
     /// Sets a `name` and `value` as new attribute for this XML node. If an attribute with the same
     /// `name` already existed on that node, its value with be overridden with a provided one.
-    pub fn set_attribute(&self, txn: &mut YTransaction, name: &str, value: &str) -> PyResult<()> {
-        txn.transact(|txn| self.0.insert_attribute(txn, name, value))
+    pub fn set_attribute(
+        &self,
+        txn: &mut YTransaction,
+        name: &str,
+        value: Py<PyAny>,
+    ) -> PyResult<()> {
+        Python::with_gil(|py| {
+            let compatible_py_type_value: CompatiblePyType =
+                value.extract(py).unwrap_or_else(|err| {
+                    err.restore(py);
+                    CompatiblePyType::None
+                });
+            txn.transact(|txn| {
+                self.0
+                    .insert_attribute(txn, name, Any::try_from(compatible_py_type_value).unwrap())
+            })
+        })
     }
 
     /// Returns a value of an attribute given its `name`. If no attribute with such name existed,

--- a/tests/test_lexical_parse.py
+++ b/tests/test_lexical_parse.py
@@ -40,25 +40,9 @@ def test_lexical_parse_in_reverse_direction():
                             ychild = ynode.push_xml_element(txn, child["__type"])
                         nodes.append((ychild, child))
                 else:
-                    # TODO simplify this, needed because set_attribute supports only string values
-                    ynode.set_attribute(txn, key, str(value))
+                    ynode.set_attribute(txn, key, value)
 
     root_json = yroot.to_dict()
-
-    # TODO remove this temporary fix
-    # it's needed because value types of some attributes in the resulting JSON don't match the expected JSON
-    # because set_attribute method in ypy supports only setting string values
-    nodes = [root_json]
-    while nodes:
-        node_json = nodes.pop(0)
-        for key, value in node_json.items():
-            if key == "children" and isinstance(value, list):
-                nodes.extend(value)
-            else:
-                if key in ["__detail", "__format", "__indent", "__mode", "__start", "__value"]:
-                    node_json[key] = int(value)
-                elif key == "__dir" and value == "None":
-                    node_json[key] = None
 
     print(f"{json.dumps(root_json, indent=4)}")
 

--- a/y_py.pyi
+++ b/y_py.pyi
@@ -978,7 +978,7 @@ class YXmlElement:
         Returns:
             A string representation wrapped in YXmlElement
         """
-    def set_attribute(self, txn: YTransaction, name: str, value: str):
+    def set_attribute(self, txn: YTransaction, name: str, value: Any):
         """
         Sets a `name` and `value` as new attribute for this XML node. If an attribute with the same
         `name` already existed on that node, its value with be overridden with a provided one.
@@ -1151,7 +1151,7 @@ class YXmlText:
         Returns:
             The string representation wrapped in 'YXmlText()'
         """
-    def set_attribute(self, txn: YTransaction, name: str, value: str):
+    def set_attribute(self, txn: YTransaction, name: str, value: Any):
         """
         Sets a `name` and `value` as new attribute for this XML node. If an attribute with the same
         `name` already existed on that node, its value with be overridden with a provided one.


### PR DESCRIPTION
Enabled inserting attributes of `Any` type for `YXmlElement` and `YXmlText` entities.