### PR TITLE
Added support for binary data in attributes

### DIFF
--- a/src/json_builder.rs
+++ b/src/json_builder.rs
@@ -60,6 +60,11 @@ impl<'a> JsonBuildable for CompatiblePyType<'a> {
 
                 buffer.push_str("]");
             }
+            CompatiblePyType::ByteArray(bytes) => {
+                return Err(PyTypeError::new_err(
+                    "Binary objects cannot be converted to JSON format"
+                ));
+            }
             CompatiblePyType::Dict(dict) => {
                 buffer.push_str("{");
                 let length = dict.len();

--- a/src/shared_types.rs
+++ b/src/shared_types.rs
@@ -65,6 +65,7 @@ pub enum CompatiblePyType<'a> {
     String(&'a pytypes::PyString),
     List(&'a pytypes::PyList),
     Dict(&'a pytypes::PyDict),
+    ByteArray(&'a pytypes::PyByteArray),
     YType(YPyType<'a>),
     None,
 }


### PR DESCRIPTION
i think it makes more sense for binary attributes to be *set* as `bytes` rather than `bytearray`, but currently when you *get* such values they are returned as `bytearray`, so i made it consistent.